### PR TITLE
Updating the README to reflect the generic nature of the script.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,6 @@
 # SWATCH-BOARD
 
-Swatch-Board is an automated file search program for searching and matching bulk swatch color images to nail polish bottle names.
-It can be used and modified for other purposes.
-
-Swatch board finds and copies files that include specific phrases in their names to a new file.
+Swatch-Board is a script for bulk file filtering *by name*.
 
 ## Installation
 
@@ -12,22 +9,32 @@ If this requirement is met, run `npm install` in the root directory.
 
 ## Usage
 
-Run the following command in the root directory:
-`node index.js [suffix] [log] [warn]`
+1. You must put the search keywords in `targets.txt`, each search phrase on its own line.
 
- - `[suffix]` String, default "". Filters only files that end with supplied string. `""` for no suffix.
- - `[log]` Bool, default true. Determines whether or not the process will log individual matches in the console.
- - `[warn]` Number, default 20. Matches below this target:filename percentage will be marked yellow when logged to the console to indicate they *might* require some attention.
+    Example:
+    ```
+    foo
+    bar baz
+    ```
+    
+    will find files with names like `FoO-bAr.jpg`, `_BAR_baz.png` and `Bar-0_Baz.gif`,
+    but will not match names like `bar.bmp`.
 
-The text file, `targets.txt`, in the root directory should contain all the names of the bottles whose swatches need to be separated.
-You can simply go to any website (ex. www.premiernailsource.com) and copy/paste all the bottle names, as-is, in the `targets.txt` file.
+2. Put the files to be filtered inside the directory named `source_files`.
 
-Place the bulk, unfiltered set of files to be extracted from into the `source_files` directory, then run the program.
-The result will be the `output_files` directory being populated with matching files.
+3. Run the following command in the root directory:
+    
+    `node index.js [suffix] [log] [warn]`
+    
+     - `[suffix]` String, default "". Filters only files that end with supplied string. `""` for no suffix.
+     - `[log]` Bool, default true. Determines whether or not the process will log individual matches in the console.
+     - `[warn]` Number, default 20. Matches below this target:filename percentage will be marked yellow when logged to the console to indicate they *might* require some attention.
 
-Notice that this program does not remove files from the `output_files` directory before rerunning the program,
+After running the script, the files that matched the target keywords will be **copied** into the directory named `output_files`.
+
+Notice that this program does not clear the `output_files` directory before rerunning the program,
 however it will warn you if you attempt to run the program while files still exist in the directory.
 This means you must manually delete the files in the directory before running the program again,
 or may want to run a different command to add other files to the output before finishing.
 
-Information on the latest process' unmatched (disparate) targets is logged in `disparate_log.log` after every search.
+Information on the latest process' unmatched (disparate) targets is logged in `disparate_targets.log` after every search (this file is overwritten every time).

--- a/index.js
+++ b/index.js
@@ -94,7 +94,7 @@ function showResults(results) {
   const [targets, matched] = results;
   const targetsNotMatched = targets.filter((target) => !matched.includes(target.raw));
 
-  fs.writeFileSync('disparate_log.log', `DISPARATE LOG - 'Logging $%&#ed up stuff since 2019'
+  fs.writeFileSync('disparate_targets.log', `DISPARATE LOG - 'Logging $%&#ed up stuff since 2019'
   Recorded ${targetsNotMatched.length} unmatched targets in last process:\n\n` + targetsNotMatched.map(t => t.raw).join("\n"));
 
   console.log(`\x1b[32m --> Completed process with ${matched.length} match${(matched.length === 1) ? '' : 'es'}\x1b[0m`);


### PR DESCRIPTION
Adding a concise example of results.

Ideas for improvements:
1) the warning about rewriting output files should require user input before continuing.
2) find/use a proper library for arguments.
3) make it possible to provide `targets.txt`, `source_files` and `output_files` via arguments.